### PR TITLE
Examples should draw same triangle

### DIFF
--- a/webgl.html
+++ b/webgl.html
@@ -57,7 +57,7 @@
     gl.clear(gl.COLOR_BUFFER_BIT);
 
     gl.useProgram(program);
-    gl.vertexAttribPointer(POSITION_ATTRIB, 3, gl.FLOAT, false, 0, 12);
+    gl.vertexAttribPointer(POSITION_ATTRIB, 3, gl.FLOAT, false, 0, 0);
     gl.enableVertexAttribArray(POSITION_ATTRIB);
 
     gl.drawArrays(gl.TRIANGLES, 0, 3);


### PR DESCRIPTION
In my testing, the two html files do not draw the same triangle.

If I remove the "offset" argument to `gl.vertexAttribPointer` in the OpenGL version, which seems to be erroneous anyway (the third vertex is off the end of the array) then webgl.html looks like webgpu.html.

Feel free to manual patch this without credit to me instead of accepting the PR, I do not care.